### PR TITLE
fix: harden PrivatizeFile against symlink following

### DIFF
--- a/lib/googlecloudsdk/core/util/files.py
+++ b/lib/googlecloudsdk/core/util/files.py
@@ -1357,10 +1357,24 @@ def PrivatizeFile(path):
   """
   try:
     if os.path.exists(path):
-      os.chmod(path, 0o600)
+      # do not follow symlinks when hardening credential/config files.
+      # use O_NOFOLLOW when available so the final path component cannot be a symlink.
+      flags = os.O_RDONLY
+      if hasattr(os, 'O_NOFOLLOW'):
+        flags |= os.O_NOFOLLOW
+      fd = os.open(path, flags)
+      try:
+        if hasattr(os, 'fchmod'):
+          os.fchmod(fd, 0o600)
+        else:
+          os.chmod(path, 0o600)
+      finally:
+        os.close(fd)
     else:
       _MakePathToFile(path, mode=0o700)
       flags = os.O_RDWR | os.O_CREAT | os.O_TRUNC
+      if hasattr(os, 'O_NOFOLLOW'):
+        flags |= os.O_NOFOLLOW
       # Accommodate Windows; stolen from python2.6/tempfile.py.
       if hasattr(os, 'O_NOINHERIT'):
         flags |= os.O_NOINHERIT


### PR DESCRIPTION
## fix: add symlink-safe open to PrivatizeFile for credential artifacts

### summary

`PrivatizeFile()` in `lib/googlecloudsdk/core/util/files.py` creates/truncates and sets permissions on sensitive config artifacts using `os.open()` without `O_NOFOLLOW`. when the config root is attacker-writable, a symlink at the final path component (e.g., `credentials.db`) can redirect filesystem effects outside the intended config root.

### change

add `os.O_NOFOLLOW` to both the `exists` and `create` branches of `PrivatizeFile`, and use `os.fchmod()` instead of `os.chmod()` to avoid a TOCTOU gap on the permission change.

### callers affected

- `lib/googlecloudsdk/core/credentials/creds.py` (credential store initialization)
- `lib/googlecloudsdk/command_lib/privateca/key_generation.py` (CA private key creation)
- `lib/googlecloudsdk/core/util/files.py:_FileOpener` (private file writes)

### test

```bash
# symlink should be rejected (patched behavior)
cfg="$(mktemp -d)"
victim="$(mktemp)"
printf "victim-before\n" > "$victim"
ln -s "$victim" "$cfg/credentials.db"

CLOUDSDK_CONFIG="$cfg" python3 - <<'PY'
import sys
from pathlib import Path
sys.path.insert(0, str(Path(".").resolve() / "lib"))
from googlecloudsdk.core import config  # type: ignore
from googlecloudsdk.core.util import files as file_utils  # type: ignore
try:
  file_utils.PrivatizeFile(config.Paths().credentials_db_path)
  raise SystemExit("unexpected: symlink was not rejected")
except Exception as e:
  print("ok: rejected:", type(e).__name__, e)
PY
```

### risk

low. `O_NOFOLLOW` only rejects symlinks in the final path component. all normal (non-symlinked) credential file operations are unchanged. the `hasattr(os, 'O_NOFOLLOW')` guard preserves Windows compatibility.
