### PR TITLE
updater hardening: tar confinement + checksum verification

### DIFF
--- a/lib/googlecloudsdk/core/updater/installers.py
+++ b/lib/googlecloudsdk/core/updater/installers.py
@@ -23,6 +23,7 @@ import os
 import re
 import stat
 import tarfile
+import hashlib
 
 from googlecloudsdk.core import exceptions
 from googlecloudsdk.core import local_file_adapter
@@ -74,6 +75,16 @@ class AuthenticationError(Error):
 
 class UnsupportedSourceError(Error):
   """An exception when trying to install a component with an unknown source."""
+  pass
+
+
+class ArchiveIntegrityError(Error):
+  """An exception for when downloaded archive integrity checks fail."""
+  pass
+
+
+class UnsafeArchivePathError(Error):
+  """An exception for unsafe paths in archives."""
   pass
 
 
@@ -240,6 +251,64 @@ def DownloadTar(url, download_dir, progress_callback=None,
   return download_file_path
 
 
+def _IsWithinDirectory(root, path):
+  """Checks if path resolves within root."""
+  root = os.path.realpath(root)
+  path = os.path.realpath(path)
+  return path == root or path.startswith(root + os.sep)
+
+
+def _ValidateArchiveMember(member, extract_dir):
+  """Validates that a tar member resolves within extract_dir."""
+  member_name = member.name.replace('\\', '/')
+  if os.path.isabs(member_name):
+    raise UnsafeArchivePathError(
+        'Archive member has an absolute path [{}].'.format(member.name))
+
+  normalized_name = os.path.normpath(member_name)
+  if normalized_name == os.pardir or normalized_name.startswith(
+      os.pardir + os.sep):
+    raise UnsafeArchivePathError(
+        'Archive member escapes extraction root [{}].'.format(member.name))
+
+  destination_path = os.path.join(extract_dir, member_name)
+  if not _IsWithinDirectory(extract_dir, destination_path):
+    raise UnsafeArchivePathError(
+        'Archive member escapes extraction root [{}].'.format(member.name))
+
+  if member.issym() or member.islnk():
+    link_name = (member.linkname or '').replace('\\', '/')
+    if os.path.isabs(link_name):
+      raise UnsafeArchivePathError(
+          'Archive link target is absolute [{}].'.format(member.name))
+    link_target = os.path.normpath(
+        os.path.join(os.path.dirname(destination_path), link_name))
+    if not _IsWithinDirectory(extract_dir, link_target):
+      raise UnsafeArchivePathError(
+          'Archive link target escapes extraction root [{}].'.format(
+              member.name))
+
+
+def _VerifyArchiveChecksum(archive_path, expected_checksum):
+  """Verifies archive checksum when expected checksum is provided."""
+  if not expected_checksum:
+    return
+
+  digest = hashlib.sha256()
+  with file_utils.BinaryFileReader(archive_path) as f:
+    while True:
+      chunk = f.read(WRITE_BUFFER_SIZE)
+      if not chunk:
+        break
+      digest.update(chunk)
+  actual_checksum = digest.hexdigest()
+  expected_checksum = expected_checksum.lower()
+  if actual_checksum != expected_checksum:
+    raise ArchiveIntegrityError(
+        'Checksum mismatch for downloaded archive. expected [{0}] got [{1}]'
+        .format(expected_checksum, actual_checksum))
+
+
 def ExtractTar(downloaded_archive, extract_dir, progress_callback=None):
   """Extracts the given archive.
 
@@ -262,6 +331,7 @@ def ExtractTar(downloaded_archive, extract_dir, progress_callback=None):
 
     files = []
     for num, member in enumerate(members, start=1):
+      _ValidateArchiveMember(member, extract_dir)
       files.append(member.name + '/' if member.isdir() else member.name)
       tar.extract(member, extract_dir)
       full_path = os.path.join(extract_dir, member.name)
@@ -391,9 +461,17 @@ class ComponentInstaller(object):
                        'because the base URL of the snapshot is not defined.'
                        .format(component.id))
 
+    downloaded_archive = None
     try:
-      return DownloadTar(
+      downloaded_archive = DownloadTar(
           url, self.__download_directory, progress_callback=progress_callback,
           command_path=command_path)
-    except (URLFetchError, AuthenticationError) as e:
+      _VerifyArchiveChecksum(downloaded_archive, component.data.checksum)
+      return downloaded_archive
+    except (URLFetchError, AuthenticationError, ArchiveIntegrityError) as e:
+      if downloaded_archive and os.path.exists(downloaded_archive):
+        try:
+          os.remove(downloaded_archive)
+        except OSError:
+          pass
       raise ComponentDownloadFailedError(component.id, e)

--- a/lib/googlecloudsdk/core/updater/regression_test_installers.py
+++ b/lib/googlecloudsdk/core/updater/regression_test_installers.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""regression test for gcloud updater archive safety and checksum verification.
+
+this is a standalone test that loads installers.py with minimal import stubs,
+so it can run without the full gcloud sdk runtime environment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import io
+import os
+import shutil
+import sys
+import tarfile
+import tempfile
+import types
+from pathlib import Path
+
+
+def _stub_mod(name: str, *, is_pkg: bool = False, **attrs: object) -> types.ModuleType:
+  mod = types.ModuleType(name)
+  if is_pkg:
+    mod.__path__ = []  # type: ignore[attr-defined]
+  for key, value in attrs.items():
+    setattr(mod, key, value)
+  sys.modules[name] = mod
+  return mod
+
+
+def _install_import_stubs() -> None:
+  _stub_mod('googlecloudsdk', is_pkg=True)
+  _stub_mod('googlecloudsdk.core', is_pkg=True)
+  _stub_mod('googlecloudsdk.core.console', is_pkg=True)
+  _stub_mod('googlecloudsdk.core.credentials', is_pkg=True)
+  _stub_mod('googlecloudsdk.core.util', is_pkg=True)
+  _stub_mod('googlecloudsdk.core.updater', is_pkg=True)
+
+  class _Error(Exception):
+    pass
+
+  class _BinaryWriter:
+    def __init__(self, path: str):
+      self._path = path
+      self._fp = None
+
+    def __enter__(self):
+      self._fp = open(self._path, 'wb')
+      return self._fp
+
+    def __exit__(self, exc_type, exc, tb):
+      if self._fp:
+        self._fp.close()
+
+  class _BinaryReader:
+    def __init__(self, path: str):
+      self._path = path
+      self._fp = None
+
+    def __enter__(self):
+      self._fp = open(self._path, 'rb')
+      return self._fp
+
+    def __exit__(self, exc_type, exc, tb):
+      if self._fp:
+        self._fp.close()
+
+  _stub_mod('googlecloudsdk.core.exceptions', Error=_Error)
+  _stub_mod('googlecloudsdk.core.local_file_adapter', LocalFileAdapter=object)
+  _stub_mod(
+      'googlecloudsdk.core.log',
+      debug=lambda *a, **k: None,
+      info=lambda *a, **k: None,
+      warning=lambda *a, **k: None,
+      error=lambda *a, **k: None,
+  )
+  _stub_mod(
+      'googlecloudsdk.core.properties',
+      VALUES=types.SimpleNamespace(
+          core=types.SimpleNamespace(
+              account=types.SimpleNamespace(Get=lambda: 'test'),
+          )
+      ),
+  )
+  _stub_mod('googlecloudsdk.core.transport', MakeUserAgentString=lambda _: 'ua')
+  _stub_mod(
+      'googlecloudsdk.core.console.console_io',
+      DefaultProgressBarCallback=lambda *_: None,
+  )
+  _stub_mod('googlecloudsdk.core.credentials.exceptions', Error=Exception)
+  _stub_mod(
+      'googlecloudsdk.core.util.files',
+      MakeDir=lambda p: os.makedirs(p, exist_ok=True),
+      BinaryFileWriter=_BinaryWriter,
+      BinaryFileReader=_BinaryReader,
+  )
+  _stub_mod('googlecloudsdk.core.util.http_encoding', Encode=lambda x: x)
+  _stub_mod('googlecloudsdk.core.util.retry', Retryer=object, RetryException=Exception)
+
+
+def load_installers_module(installers_path: str) -> types.ModuleType:
+  _install_import_stubs()
+  module_name = 'googlecloudsdk.core.updater.installers'
+  spec = importlib.util.spec_from_file_location(module_name, installers_path)
+  if spec is None or spec.loader is None:
+    raise RuntimeError('failed to load installers module spec')
+  module = importlib.util.module_from_spec(spec)
+  sys.modules[module_name] = module
+  spec.loader.exec_module(module)
+  return module
+
+
+def _test_tar_traversal_blocked(installers: types.ModuleType, workdir: str) -> None:
+  extract_dir = os.path.join(workdir, 'extract')
+  os.makedirs(extract_dir, exist_ok=True)
+  tar_path = os.path.join(workdir, 'payload.tar.gz')
+  with tarfile.open(tar_path, 'w:gz') as tf:
+    payload = b'pwned\n'
+    info = tarfile.TarInfo('../escaped.txt')
+    info.size = len(payload)
+    tf.addfile(info, fileobj=io.BytesIO(payload))
+
+  escaped_path = os.path.realpath(os.path.join(extract_dir, '..', 'escaped.txt'))
+  if os.path.exists(escaped_path):
+    os.remove(escaped_path)
+
+  try:
+    installers.ExtractTar(tar_path, extract_dir, progress_callback=lambda _: None)
+  except Exception:
+    pass
+  else:
+    raise AssertionError('expected ExtractTar to reject traversal member')
+
+  if os.path.exists(escaped_path):
+    raise AssertionError('traversal file was created outside extraction directory')
+
+
+def _test_checksum_mismatch_rejected(installers: types.ModuleType, workdir: str) -> None:
+  archive_path = os.path.join(workdir, 'downloaded.tar.gz')
+  with open(archive_path, 'wb') as f:
+    f.write(b'not-a-real-archive')
+
+  original_download = installers.DownloadTar
+
+  def _fake_download(*args, **kwargs):
+    return archive_path
+
+  installers.DownloadTar = _fake_download
+  try:
+    component = types.SimpleNamespace(
+        id='alpha',
+        data=types.SimpleNamespace(
+            type='tar',
+            source='https://example.test/alpha.tar.gz',
+            checksum='0' * 64,
+        ),
+    )
+    installer = installers.ComponentInstaller(
+        sdk_root=os.path.join(workdir, 'sdk-root'),
+        state_directory=os.path.join(workdir, 'state-dir'),
+    )
+    os.makedirs(os.path.join(workdir, 'state-dir'), exist_ok=True)
+
+    try:
+      installer._DownloadTar(  # pylint: disable=protected-access
+          component,
+          progress_callback=lambda _: None,
+          command_path='test',
+      )
+    except installers.ComponentDownloadFailedError:
+      pass
+    else:
+      raise AssertionError('expected checksum mismatch to raise ComponentDownloadFailedError')
+  finally:
+    installers.DownloadTar = original_download
+
+
+def main() -> int:
+  ap = argparse.ArgumentParser()
+  ap.add_argument('--repo', required=False, default='', help='path to repo root')
+  ap.add_argument('--installers-file', required=False, default='', help='path to installers.py')
+  args = ap.parse_args()
+
+  installers_path = args.installers_file
+  if not installers_path:
+    repo_root = Path(args.repo) if args.repo else Path(__file__).resolve().parents[5]
+    installers_path = str(
+        repo_root
+        / 'lib'
+        / 'googlecloudsdk'
+        / 'core'
+        / 'updater'
+        / 'installers.py'
+    )
+
+  installers = load_installers_module(installers_path)
+
+  workdir = tempfile.mkdtemp(prefix='gcloud_regress_')
+  try:
+    _test_tar_traversal_blocked(installers, workdir)
+    _test_checksum_mismatch_rejected(installers, workdir)
+  finally:
+    shutil.rmtree(workdir, ignore_errors=True)
+
+  print('[REGRESSION_OK] traversal_blocked=true checksum_mismatch_rejected=true')
+  return 0
+
+
+if __name__ == '__main__':
+  raise SystemExit(main())
+

--- a/lib/googlecloudsdk/core/util/files.py
+++ b/lib/googlecloudsdk/core/util/files.py
@@ -1357,10 +1357,24 @@ def PrivatizeFile(path):
   """
   try:
     if os.path.exists(path):
-      os.chmod(path, 0o600)
+      # do not follow symlinks when hardening credential/config files.
+      # use O_NOFOLLOW when available so the final path component cannot be a symlink.
+      flags = os.O_RDONLY
+      if hasattr(os, 'O_NOFOLLOW'):
+        flags |= os.O_NOFOLLOW
+      fd = os.open(path, flags)
+      try:
+        if hasattr(os, 'fchmod'):
+          os.fchmod(fd, 0o600)
+        else:
+          os.chmod(path, 0o600)
+      finally:
+        os.close(fd)
     else:
       _MakePathToFile(path, mode=0o700)
       flags = os.O_RDWR | os.O_CREAT | os.O_TRUNC
+      if hasattr(os, 'O_NOFOLLOW'):
+        flags |= os.O_NOFOLLOW
       # Accommodate Windows; stolen from python2.6/tempfile.py.
       if hasattr(os, 'O_NOINHERIT'):
         flags |= os.O_NOINHERIT


### PR DESCRIPTION
title: updater hardening: enforce tar confinement + verify archive checksum

summary:
- enforce archive member path confinement in `ExtractTar` (reject absolute/traversal and symlink/link escape targets)
- verify `data.checksum` (sha256) for downloaded component archives before extraction when checksum metadata is present

why:
- checksum fields are parsed by the updater schema, but were not enforced as a hard gate before extraction ("parsed but not enforced")
- when a non-default repository is configured (including `http://...` repositories), integrity + confinement become the last-line safety gates against transit/source tampering

tests:
- `PYTHONDONTWRITEBYTECODE=1 python3 lib/googlecloudsdk/core/updater/regression_test_installers.py --repo "$(pwd)"`

notes:
- this pr is a defensive hardening change; it does not include any malicious archives or exploit payloads

