### PR TITLE
harden iac remediation PR creation

### DIFF
--- a/lib/googlecloudsdk/api_lib/scc/iac_remediation/git.py
+++ b/lib/googlecloudsdk/api_lib/scc/iac_remediation/git.py
@@ -165,12 +165,21 @@ def raise_pr(pr_title, pr_desc, remote_name, branch_name, base_branch):
     base_branch: The main branch name to be which PR needs to be merged.
   """
   worktree_dir = get_working_tree_dir(remote_name, branch_name)
-  pr_command = (
-      f'gh pr create --base {base_branch} --head {branch_name} --title'
-      f' "{pr_title}" --body "{pr_desc}"'
-  )
+  pr_command = [
+      'gh',
+      'pr',
+      'create',
+      '--base',
+      base_branch,
+      '--head',
+      branch_name,
+      '--title',
+      pr_title,
+      '--body',
+      pr_desc,
+  ]
   subprocess.run(  # create a PR
-      pr_command, shell=True, check=False, cwd=worktree_dir,
+      pr_command, check=False, cwd=worktree_dir,
       stdout=subprocess.PIPE, stderr=subprocess.PIPE,
   )
   subprocess.run(  # cleanup the worktree


### PR DESCRIPTION
use an argv list for `gh pr create` instead of building a shell command string. this keeps branch, base, title, and body values out of shell parsing while preserving the existing flow and cleanup behavior.

validation:
- `python3 -m py_compile lib/googlecloudsdk/api_lib/scc/iac_remediation/git.py`
- AST check confirming `raise_pr()` no longer uses `shell=True`
