### PR TITLE
credentials: block credential attachment to non-universe endpoints

### DIFF
--- a/lib/googlecloudsdk/core/credentials/http.py
+++ b/lib/googlecloudsdk/core/credentials/http.py
@@ -119,6 +119,13 @@ class RequestWrapper(transport.CredentialWrappingMixin,
       http_client = google_auth_httplib2.AuthorizedHttp(creds, http_client)
     else:
       http_client = creds.authorize(http_client)
+    orig_request = http_client.request
+
+    def WrappedRequest(uri, *args, **kwargs):
+      transport.ValidateCredentialedRequestUrl(uri)
+      return orig_request(uri, *args, **kwargs)
+
+    http_client.request = WrappedRequest
     return http_client
 
   def WrapQuota(

--- a/lib/googlecloudsdk/core/credentials/regression_test_non_universe_credential_boundary.py
+++ b/lib/googlecloudsdk/core/credentials/regression_test_non_universe_credential_boundary.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""regression test for non-universe credential attachment blocking."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _stub_mod(
+    name: str, *, is_pkg: bool = False, **attrs: object
+) -> types.ModuleType:
+  mod = types.ModuleType(name)
+  if is_pkg:
+    mod.__path__ = []  # type: ignore[attr-defined]
+  for key, value in attrs.items():
+    setattr(mod, key, value)
+  sys.modules[name] = mod
+  return mod
+
+
+def _install_import_stubs() -> types.SimpleNamespace:
+  _stub_mod('googlecloudsdk', is_pkg=True)
+  _stub_mod('googlecloudsdk.core', is_pkg=True)
+  _stub_mod('googlecloudsdk.core.credentials', is_pkg=True)
+  _stub_mod('googlecloudsdk.core.util', is_pkg=True)
+  _stub_mod('google', is_pkg=True)
+  _stub_mod('google.auth', is_pkg=True)
+
+  class _Error(Exception):
+    pass
+
+  override_state = types.SimpleNamespace(
+      allow_non_universe=False, universe_domain='googleapis.com'
+  )
+
+  _stub_mod('googlecloudsdk.core.context_aware')
+  _stub_mod('googlecloudsdk.core.exceptions', Error=_Error)
+  _stub_mod(
+      'googlecloudsdk.core.log',
+      debug=lambda *a, **k: None,
+      info=lambda *a, **k: None,
+      warning=lambda *a, **k: None,
+      error=lambda *a, **k: None,
+  )
+  _stub_mod(
+      'googlecloudsdk.core.properties',
+      GetUniverseDomain=lambda: override_state.universe_domain,
+      VALUES=types.SimpleNamespace(
+          core=types.SimpleNamespace(
+              allow_non_universe_credentialed_endpoints=types.SimpleNamespace(
+                  GetBool=lambda: override_state.allow_non_universe
+              )
+          )
+      ),
+  )
+  _stub_mod('googlecloudsdk.core.transport')
+  _stub_mod('googlecloudsdk.core.credentials.creds')
+  _stub_mod('googlecloudsdk.core.credentials.exceptions')
+  _stub_mod('googlecloudsdk.core.credentials.store')
+  _stub_mod('googlecloudsdk.core.util.files')
+  _stub_mod('google.auth.exceptions', RefreshError=Exception)
+
+  return override_state
+
+
+def load_transport_module(
+    transport_path: str,
+) -> tuple[types.ModuleType, types.SimpleNamespace]:
+  override_state = _install_import_stubs()
+  module_name = 'googlecloudsdk.core.credentials.transport'
+  spec = importlib.util.spec_from_file_location(module_name, transport_path)
+  if spec is None or spec.loader is None:
+    raise RuntimeError('failed to load transport module spec')
+  module = importlib.util.module_from_spec(spec)
+  sys.modules[module_name] = module
+  spec.loader.exec_module(module)
+  return module, override_state
+
+
+def _test_googleapis_url_allowed(transport_module: types.ModuleType) -> None:
+  transport_module.ValidateCredentialedRequestUrl(
+      'https://compute.googleapis.com/compute/v1/projects/p'
+  )
+
+
+def _test_non_universe_url_blocked(transport_module: types.ModuleType) -> None:
+  try:
+    transport_module.ValidateCredentialedRequestUrl(
+        'https://attacker.example/compute/v1/projects/p'
+    )
+  except Exception as exc:  # pylint: disable=broad-except
+    if 'allow_non_universe_credentialed_endpoints' not in str(exc):
+      raise AssertionError(
+          'unexpected error message: {}'.format(exc)
+      ) from exc
+    return
+  raise AssertionError('expected non-universe credentialed URL to be rejected')
+
+
+def _test_non_universe_url_opt_in(
+    transport_module: types.ModuleType, override_state: types.SimpleNamespace
+) -> None:
+  override_state.allow_non_universe = True
+  try:
+    transport_module.ValidateCredentialedRequestUrl(
+        'https://attacker.example/compute/v1/projects/p'
+    )
+  finally:
+    override_state.allow_non_universe = False
+
+
+def main() -> int:
+  ap = argparse.ArgumentParser()
+  ap.add_argument(
+      '--repo', required=False, default='', help='path to repo root'
+  )
+  ap.add_argument(
+      '--transport-file',
+      required=False,
+      default='',
+      help='path to core/credentials/transport.py',
+  )
+  args = ap.parse_args()
+
+  transport_path = args.transport_file
+  if not transport_path:
+    repo_root = Path(args.repo) if args.repo else Path(__file__).resolve().parents[5]
+    transport_path = str(
+        repo_root
+        / 'lib'
+        / 'googlecloudsdk'
+        / 'core'
+        / 'credentials'
+        / 'transport.py'
+    )
+
+  transport_module, override_state = load_transport_module(transport_path)
+
+  _test_googleapis_url_allowed(transport_module)
+  _test_non_universe_url_blocked(transport_module)
+  _test_non_universe_url_opt_in(transport_module, override_state)
+
+  print(
+      '[REGRESSION_OK] googleapis_url=true '
+      'non_universe_blocked=true opt_in_override=true'
+  )
+  return 0
+
+
+if __name__ == '__main__':
+  raise SystemExit(main())

--- a/lib/googlecloudsdk/core/credentials/requests.py
+++ b/lib/googlecloudsdk/core/credentials/requests.py
@@ -114,6 +114,7 @@ class RequestWrapper(
       wrapped_request = http_client.request
       http_client.request = orig_request
 
+      transport.ValidateCredentialedRequestUrl(url)
       creds.before_request(auth_request, method, url, headers)
 
       http_client.request = wrapped_request

--- a/lib/googlecloudsdk/core/credentials/transport.py
+++ b/lib/googlecloudsdk/core/credentials/transport.py
@@ -32,6 +32,7 @@ from googlecloudsdk.core.util import files
 
 import six
 from google.auth import exceptions as google_auth_exceptions
+from six.moves.urllib.parse import urlparse
 
 
 class Error(exceptions.Error):
@@ -142,6 +143,37 @@ class CredentialWrappingMixin(object):
   @abc.abstractmethod
   def AuthorizeClient(self, http_client, credentials):
     """Returns an http_client authorized with the given credentials."""
+
+
+def _HostMatchesUniverseDomain(hostname, universe_domain):
+  """Returns True if hostname is inside the active universe domain."""
+  if not hostname or not universe_domain:
+    return False
+  hostname = hostname.lower().rstrip('.')
+  universe_domain = universe_domain.lower().rstrip('.')
+  return (
+      hostname == universe_domain or
+      hostname.endswith('.' + universe_domain)
+  )
+
+
+def ValidateCredentialedRequestUrl(url):
+  """Rejects credential attachment to non-universe hosts unless opted in."""
+  if properties.VALUES.core.allow_non_universe_credentialed_endpoints.GetBool():
+    return
+
+  host = urlparse(url).hostname
+  universe_domain = properties.GetUniverseDomain()
+  if _HostMatchesUniverseDomain(host, universe_domain):
+    return
+
+  raise Error(
+      'Refusing to attach credentials to non-universe host [{host}]. To '
+      'override this behavior, set '
+      '[core/allow_non_universe_credentialed_endpoints] to true.'.format(
+          host=host
+      )
+  )
 
 
 def _GetIAMAuthHandlers(authority_selector, authorization_token_file):

--- a/lib/googlecloudsdk/core/properties.py
+++ b/lib/googlecloudsdk/core/properties.py
@@ -2538,6 +2538,16 @@ class _SectionCore(_Section):
         help_text='Sets the domain of the universe to use for API requests.',
         default='googleapis.com',
     )
+    self.allow_non_universe_credentialed_endpoints = self._AddBool(
+        'allow_non_universe_credentialed_endpoints',
+        help_text=(
+            'Allows credentialed requests to target hosts outside the active '
+            'universe domain. Warning: this may disclose bearer tokens to '
+            'non-universe endpoints.'
+        ),
+        hidden=True,
+        default=False,
+    )
 
     self.credentialed_hosted_repo_domains = self._Add(
         'credentialed_hosted_repo_domains', hidden=True


### PR DESCRIPTION
this hardens credentialed gcloud API traffic when a request is pointed at a host outside the active universe domain.

today the credential wrappers attach credentials to whatever absolute URL they are given. if a request reaches a non-universe host, the auth layer still decorates that request before it goes out.

this patch adds a shared boundary check before credentials are attached:

- `lib/googlecloudsdk/core/credentials/transport.py` centralizes the host-vs-universe-domain check
- `lib/googlecloudsdk/core/credentials/requests.py` validates the destination before `creds.before_request(...)`
- `lib/googlecloudsdk/core/credentials/http.py` applies the same check to the httplib2 / `AuthorizedHttp` path
- a hidden opt-in property, `core/allow_non_universe_credentialed_endpoints`, preserves explicit test and debug flows that intentionally need credentialed requests to a non-universe endpoint

validation:

- `python3 lib/googlecloudsdk/core/credentials/regression_test_non_universe_credential_boundary.py --repo .`
- `python3 -m py_compile lib/googlecloudsdk/core/properties.py lib/googlecloudsdk/core/credentials/transport.py lib/googlecloudsdk/core/credentials/requests.py lib/googlecloudsdk/core/credentials/http.py lib/googlecloudsdk/core/credentials/regression_test_non_universe_credential_boundary.py`
